### PR TITLE
Refactor(synth): Align with NVDA core to fix settings panel crash

### DIFF
--- a/addon/synthDrivers/WorldVoice/VoiceSettingsDialogs.py
+++ b/addon/synthDrivers/WorldVoice/VoiceSettingsDialogs.py
@@ -1,71 +1,12 @@
-from autoSettingsUtils.driverSetting import BooleanDriverSetting, NumericDriverSetting
-import gui
 from gui.settingsDialogs import VoiceSettingsPanel
-from logHandler import log
-
 
 class WorldVoiceVoiceSettingsPanel(VoiceSettingsPanel):
-	def makeSettings(self, settingsSizer):
-		self.createDriverSettings()
-		super().makeSettings(settingsSizer)
-
-	def createDriverSettings(self, changedSetting=None):
-		"""
-		Creates, hides or updates existing GUI controls for all of supported settings.
-		"""
-		settingsInst = self.getSettings()
-		settingsStorage = self._getSettingsStorage()
-		# firstly check already created options
-		for name, sizer in self.sizerDict.items():
-			if name == changedSetting:
-				# Changing a setting shouldn't cause that setting itself to disappear.
-				continue
-			if not settingsInst.isSupported(name):
-				self.settingsSizer.Hide(sizer)
-		# Create new controls, update already existing
-		if gui._isDebug():
-			log.debug(f"Current sizerDict: {self.sizerDict!r}")
-			log.debug(f"Current supportedSettings: {self.getSettings().supportedSettings!r}")
-		for setting in settingsInst.allSupportedSettings:
-			if setting.id == changedSetting:
-				# Changing a setting shouldn't cause that setting's own values to change.
-				continue
-			if setting.id in self.sizerDict:  # update a value
-				self._updateValueForControl(setting, settingsStorage)
-			else:  # create a new control
-				self._createNewControl(setting, settingsStorage)
-		# Update graphical layout of the dialog
-		self.settingsSizer.Layout()
-
-	def _updateValueForControl(self, setting, settingsStorage):
-		self.settingsSizer.Show(self.sizerDict[setting.id])
-		if isinstance(setting, NumericDriverSetting):
-			getattr(self, f"{setting.id}Slider").SetValue(
-				getattr(settingsStorage, setting.id)
-			)
-		elif isinstance(setting, BooleanDriverSetting):
-			getattr(self, f"{setting.id}Checkbox").SetValue(
-				getattr(settingsStorage, setting.id)
-			)
-		else:
-			stringSettingAttribName = f"_{setting.id}s"
-			setattr(
-				self,
-				stringSettingAttribName,
-				# Settings are stored as an ordered dict.
-				# Therefore wrap this inside a list call.
-				list(getattr(
-					self.getSettings(),
-					f"available{setting.id.capitalize()}s"
-				).values())
-			)
-			options = getattr(self, stringSettingAttribName)
-
-			lCombo = getattr(self, f"{setting.id}List")
-			lCombo.SetItems([x.displayName for x in options])
-			try:
-				cur = getattr(settingsStorage, setting.id)
-				indexOfItem = [x.id for x in options].index(cur)
-				lCombo.SetSelection(indexOfItem)
-			except ValueError:
-				pass
+	"""
+	A custom voice settings panel for WorldVoice.
+	By ensuring the WorldVoice synth driver correctly implements the 'supportedSettings'
+	property, this panel can be greatly simplified. It inherits all necessary UI
+	creation logic from its parent classes (VoiceSettingsPanel and AutoSettingsMixin),
+	which automatically build the settings interface based on 'supportedSettings'.
+	No custom methods are needed here anymore.
+	"""
+	pass

--- a/addon/synthDrivers/WorldVoice/__init__.py
+++ b/addon/synthDrivers/WorldVoice/__init__.py
@@ -143,95 +143,13 @@ class SynthDriver(SynthDriver):
 
 	@property
 	def supportedSettings(self):
-		settings = [
-			SynthDriver.VoiceSetting(),
-		]
-		settings.append(SynthDriver.VariantSetting())
-		settings.append(SynthDriver.RateSetting())
-		if self._voiceManager.defaultVoiceInstance.engine in ["OneCore", "SAPI5", "Espeak", "RH", "VE"]:
-			settings.append(SynthDriver.RateBoostSetting())
-		settings.extend([
-			SynthDriver.PitchSetting(),
-		])
-		if self._voiceManager.defaultVoiceInstance.engine in ["aisound"]:
-			settings.append(SynthDriver.InflectionSetting())
-		settings.extend([
-			SynthDriver.VolumeSetting(),
-			BooleanDriverSetting(
-				"uwv",
-				_("Detect language based on Unicode characters"),
-				availableInSettingsRing=True,
-				defaultVal=True,
-				displayName=_("Detect language based on Unicode characters"),
-			),
-			BooleanDriverSetting(
-				"cni",
-				_("Ignore comma between number"),
-				defaultVal=False,
-			),
-			DriverSetting(
-				"numlan",
-				# Translators: Label for a setting in voice settings dialog.
-				_("Number &Language"),
-				availableInSettingsRing=True,
-				defaultVal="default",
-				# Translators: Label for a setting in synth settings ring.
-				displayName=_("Number Language"),
-			),
-			DriverSetting(
-				"nummod",
-				# Translators: Label for a setting in voice settings dialog.
-				_("Number &Mode"),
-				availableInSettingsRing=True,
-				defaultVal="value",
-				# Translators: Label for a setting in synth settings ring.
-				displayName=_("Number Mode"),
-			),
-			NumericDriverSetting(
-				"globalwaitfactor",
-				# Translators: Label for a setting in voice settings dialog.
-				_("Global wait factor"),
-				availableInSettingsRing=True,
-				defaultVal=50,
-				minStep=10,
-			),
-			NumericDriverSetting(
-				"numberwaitfactor",
-				# Translators: Label for a setting in voice settings dialog.
-				_("Number wait factor"),
-				availableInSettingsRing=True,
-				defaultVal=0,
-				minStep=1,
-			),
-			NumericDriverSetting(
-				"itemwaitfactor",
-				# Translators: Label for a setting in voice settings dialog.
-				_("item wait factor"),
-				availableInSettingsRing=True,
-				defaultVal=0,
-				minStep=1,
-			),
-			NumericDriverSetting(
-				"sayallwaitfactor",
-				# Translators: Label for a setting in voice settings dialog.
-				_("Say all wait factor"),
-				availableInSettingsRing=True,
-				defaultVal=0,
-				minStep=1,
-			),
-			NumericDriverSetting(
-				"chinesespacewaitfactor",
-				# Translators: Label for a setting in voice settings dialog.
-				_("Chinese space wait factor"),
-				availableInSettingsRing=True,
-				defaultVal=0,
-				minStep=1,
-			),
-		])
-		return settings
-
-	@property
-	def allSupportedSettings(self):
+		"""
+		This property returns ALL settings the driver might ever support.
+		NVDA's settings dialog will automatically check which ones are currently
+		supported by the active voice (using the isSupported method) and show/hide them.
+		This eliminates the need for 'allSupportedSettings' and makes the driver
+		compatible with the standard VoiceSettingsPanel.
+		"""
 		settings = [
 			SynthDriver.VoiceSetting(),
 			SynthDriver.VariantSetting(),


### PR DESCRIPTION

### **Description**

This PR refactors the WorldVoice synth driver to fix an `AttributeError` that occurs when switching from WorldVoice to any other standard synthesizer (e.g., "Windows OneCore", "SAPI5"). The error prevented the settings panel from loading for the newly selected synth.

### **Root Cause**

The crash was caused by the custom `WorldVoiceVoiceSettingsPanel`, which incorrectly tried to access a non-standard `allSupportedSettings` attribute. When the active synthesizer changed to a standard one (like SAPI5), this attribute was not found, leading to the `AttributeError`.

The custom panel was attempting to build a settings UI for a driver it wasn't designed for.

### **Changes**

This refactoring aligns the WorldVoice driver with NVDA's standard design patterns for synthesizers:

1.  **In `__init__.py`:**
    *   The `allSupportedSettings` property has been removed.
    *   The standard `supportedSettings` property is now implemented to return a complete, static list of all possible settings. This delegates the responsibility of dynamically showing/hiding UI controls to NVDA's core `AutoSettingsMixin`, which checks `isSupported()` for each setting.

2.  **In `VoiceSettingsDialogs.py`:**
    *   The `WorldVoiceVoiceSettingsPanel` has been simplified to an empty `pass` class.
    *   All custom UI-rendering logic has been removed, as the parent `VoiceSettingsPanel` can now handle the driver correctly due to the changes above.

### **Benefits of this Refactor**

*   **Fixes the crash:** The `AttributeError` is eliminated, Fixed #41.
*   **Improves Compatibility:** The settings panel now works correctly when switching to and from any standard NVDA synthesizer.
*   **Simplifies Code:** Removes complex and error-prone custom UI logic, making the addon easier to maintain and more robust.
