### PR TITLE
Fix: rateBoost hotkey only affects default voice instance

### DIFF
--- a/addon/synthDrivers/WorldVoice/__init__.py
+++ b/addon/synthDrivers/WorldVoice/__init__.py
@@ -481,6 +481,7 @@ class SynthDriver(SynthDriver):
 
 	def _set_rateBoost(self, enable):
 		self._voiceManager.defaultVoiceInstance.rateBoost = enable
+		self._voiceManager.onVoiceParameterConsistent(self._voiceManager.defaultVoiceInstance)
 
 	def _get_uwv(self):
 		return self._uwv


### PR DESCRIPTION
## Summary

Fix rateBoost hotkey handling so toggling the setting through the keyboard shortcut propagates beyond the default voice instance.

## Root Cause

`_set_rateBoost` only updated `defaultVoiceInstance.rateBoost`. Other cached language voice instances were not synchronized, so users had to open and save the settings dialog before those voices picked up the new rateBoost value.

## User Impact

Users switching between languages now get consistent rateBoost behavior immediately after using the hotkey.

## Validation

- Ran `git diff --check`.
- Ran `python -m py_compile addon/synthDrivers/WorldVoice/__init__.py`.