### PR TITLE
Fix cancellable pauses, waitfactor, variants, and synth shutdown

### DIFF
--- a/addon/synthDrivers/WorldVoice/__init__.py
+++ b/addon/synthDrivers/WorldVoice/__init__.py
@@ -121,7 +121,8 @@ class SynthDriver(SynthDriver):
 		settings = [
 			SynthDriver.VoiceSetting(),
 		]
-		settings.append(SynthDriver.VariantSetting())
+		if self._defaultVoiceHasVariants():
+			settings.append(SynthDriver.VariantSetting())
 		settings.append(SynthDriver.RateSetting())
 		if "rateBoost" in self._voiceManager.defaultVoiceInstance.__class__.supportedSettings():
 			settings.append(SynthDriver.RateBoostSetting())
@@ -287,6 +288,12 @@ class SynthDriver(SynthDriver):
 			),
 		]
 		return settings
+
+	def _defaultVoiceHasVariants(self):
+		try:
+			return len(self._voiceManager.defaultVoiceInstance.variants) > 0
+		except Exception:
+			return False
 
 	def __init__(self):
 		WVStart.notify()
@@ -487,9 +494,16 @@ class SynthDriver(SynthDriver):
 		return values
 
 	def _get_variant(self):
-		return self._voiceManager.defaultVoiceInstance.variant
+		variant = self._voiceManager.defaultVoiceInstance.variant
+		availableVariants = self._get_availableVariants()
+		if variant not in availableVariants:
+			return next(iter(availableVariants))
+		return variant
 
 	def _set_variant(self, value):
+		availableVariants = self._get_availableVariants()
+		if value not in availableVariants:
+			value = next(iter(availableVariants))
 		self._voiceManager.defaultVoiceInstance.variant = value
 		self._voiceManager.defaultVoiceInstance.commit()
 		if config.conf["WorldVoice"]["autoLanguageSwitching"]["KeepMainLocaleParameterConsistent"]:

--- a/addon/synthDrivers/WorldVoice/__init__.py
+++ b/addon/synthDrivers/WorldVoice/__init__.py
@@ -323,10 +323,23 @@ class SynthDriver(SynthDriver):
 		try:
 			self.cancel()
 		except BaseException:
-			log.error("WorldVoice terminate", exc_info=True)
+			log.error("WorldVoice terminate cancel", exc_info=True)
 
-		self._voiceManager.terminate()
-		self._voiceManager = None
+		try:
+			if self.taskManager:
+				self.taskManager.shutdown()
+		except BaseException:
+			log.error("WorldVoice taskManager shutdown", exc_info=True)
+		finally:
+			self.taskManager = None
+
+		try:
+			if self._voiceManager:
+				self._voiceManager.terminate()
+		except BaseException:
+			log.error("WorldVoice voiceManager terminate", exc_info=True)
+		finally:
+			self._voiceManager = None
 
 		WVEnd.notify()
 

--- a/addon/synthDrivers/WorldVoice/driver/Cerence/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/Cerence/__init__.py
@@ -4,7 +4,7 @@ import locale
 from .driver import SynthDriver
 from .driver import TtsSetParamList
 from .driver import ttsapi
-from .driver.ttsapi.veTypes import VE_PARAM_LANGUAGE, VE_PARAM_VOICE_OPERATING_POINT, VeError
+from .driver.ttsapi.veTypes import VE_PARAM_LANGUAGE, VE_PARAM_VOICE_OPERATING_POINT, VE_PARAM_WAITFACTOR, VeError
 from synthDrivers.WorldVoice.driver import Voice
 
 
@@ -42,13 +42,17 @@ class Voice(Voice):
 	@property
 	def waitfactor(self):
 		if self.core:
-			self._waitfactor = self.core.waitfactor
-		return self._waitfactor
+			try:
+				self._waitfactor = int(self.core.getParameter(self.core.getVoiceInstance(self.name), VE_PARAM_WAITFACTOR))
+			except (VeError, RuntimeError, TypeError, ValueError):
+				pass
+		return getattr(self, "_waitfactor", 0)
 
 	@waitfactor.setter
 	def waitfactor(self, value):
+		self._waitfactor = int(value)
 		if self.core:
-			self.core.waitfactor = value
+			TtsSetParamList(self.core.getVoiceInstance(self.name), (VE_PARAM_WAITFACTOR, self._waitfactor))()
 
 	@classmethod
 	def voices(cls):

--- a/addon/synthDrivers/WorldVoice/driver/Cerence/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/Cerence/__init__.py
@@ -50,9 +50,10 @@ class Voice(Voice):
 
 	@waitfactor.setter
 	def waitfactor(self, value):
-		self._waitfactor = int(value)
+		waitfactor = int(value)
 		if self.core:
-			TtsSetParamList(self.core.getVoiceInstance(self.name), (VE_PARAM_WAITFACTOR, self._waitfactor))()
+			TtsSetParamList(self.core.getVoiceInstance(self.name), (VE_PARAM_WAITFACTOR, waitfactor))()
+		self._waitfactor = waitfactor
 
 	@classmethod
 	def voices(cls):

--- a/addon/synthDrivers/WorldVoice/driver/Cerence/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/Cerence/__init__.py
@@ -1,5 +1,6 @@
 import languageHandler
 import locale
+from logHandler import log
 
 from .driver import SynthDriver
 from .driver import TtsSetParamList
@@ -19,13 +20,19 @@ class Voice(Voice):
 
 	@variant.setter
 	def variant(self, value):
-		self._variant = value
 		try:
-			TtsSetParamList(self.core.getVoiceInstance(self.name), (VE_PARAM_VOICE_OPERATING_POINT, value))()
-		except VeError:
-			pass
-		except BaseException:
-			pass
+			variantIds = [item["id"] for item in self.variants]
+		except (VeError, RuntimeError, TypeError, ValueError, AttributeError):
+			variantIds = []
+		if variantIds and value not in variantIds:
+			value = variantIds[0]
+		if self.core:
+			try:
+				TtsSetParamList(self.core.getVoiceInstance(self.name), (VE_PARAM_VOICE_OPERATING_POINT, value))()
+			except Exception:
+				log.debugWarning(f"Unable to set variant for voice {self.name}", exc_info=True)
+				return
+		self._variant = value
 
 	@property
 	def variants(self):

--- a/addon/synthDrivers/WorldVoice/driver/VE/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/VE/__init__.py
@@ -45,9 +45,10 @@ class Voice(Voice):
 
 	@waitfactor.setter
 	def waitfactor(self, value):
-		self._waitfactor = int(value)
+		waitfactor = int(value)
 		if self.core:
-			TtsSetParamList(self.core.getVoiceInstance(self.name), (VE_PARAM_WAITFACTOR, self._waitfactor))()
+			TtsSetParamList(self.core.getVoiceInstance(self.name), (VE_PARAM_WAITFACTOR, waitfactor))()
+		self._waitfactor = waitfactor
 
 	@classmethod
 	def voices(cls):

--- a/addon/synthDrivers/WorldVoice/driver/VE/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/VE/__init__.py
@@ -1,5 +1,6 @@
 import languageHandler
 import locale
+from logHandler import log
 from synthDriverHandler import LanguageInfo
 
 from .driver import SynthDriver, TtsSetParamList
@@ -19,11 +20,19 @@ class Voice(Voice):
 
 	@variant.setter
 	def variant(self, value):
-		self._variant = value
 		try:
-			TtsSetParamList(self.core.getVoiceInstance(self.name), (VE_PARAM_VOICE_OPERATING_POINT, value))()
-		except VeError:
-			pass
+			variantIds = [item["id"] for item in self.variants]
+		except (VeError, RuntimeError, TypeError, ValueError, AttributeError):
+			variantIds = []
+		if variantIds and value not in variantIds:
+			value = variantIds[0]
+		if self.core:
+			try:
+				TtsSetParamList(self.core.getVoiceInstance(self.name), (VE_PARAM_VOICE_OPERATING_POINT, value))()
+			except Exception:
+				log.debugWarning(f"Unable to set variant for voice {self.name}", exc_info=True)
+				return
+		self._variant = value
 
 	@property
 	def variants(self):

--- a/addon/synthDrivers/WorldVoice/driver/VE/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/VE/__init__.py
@@ -4,7 +4,7 @@ from synthDriverHandler import LanguageInfo
 
 from .driver import SynthDriver, TtsSetParamList
 from .driver import ve2
-from .driver.ve2.veTypes import VE_PARAM_LANGUAGE, VE_PARAM_VOICE_OPERATING_POINT, VeError
+from .driver.ve2.veTypes import VE_PARAM_LANGUAGE, VE_PARAM_VOICE_OPERATING_POINT, VE_PARAM_WAITFACTOR, VeError
 from synthDrivers.WorldVoice.driver import Voice
 
 
@@ -37,13 +37,17 @@ class Voice(Voice):
 	@property
 	def waitfactor(self):
 		if self.core:
-			self._waitfactor = self.core.waitfactor
-		return self._waitfactor
+			try:
+				self._waitfactor = int(self.core.getParameter(self.core.getVoiceInstance(self.name), VE_PARAM_WAITFACTOR))
+			except (VeError, RuntimeError, TypeError, ValueError):
+				pass
+		return getattr(self, "_waitfactor", 0)
 
 	@waitfactor.setter
 	def waitfactor(self, value):
+		self._waitfactor = int(value)
 		if self.core:
-			self.core.waitfactor = value
+			TtsSetParamList(self.core.getVoiceInstance(self.name), (VE_PARAM_WAITFACTOR, self._waitfactor))()
 
 	@classmethod
 	def voices(cls):

--- a/addon/synthDrivers/WorldVoice/driver/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/__init__.py
@@ -173,14 +173,19 @@ class Voice(object):
 	@classmethod
 	def engineOn(cls):
 		if not cls.core:
+			driverName = getattr(cls.synth_driver_class, "name", None)
+			if driverName and driverName not in config.conf["speech"]:
+				config.conf["speech"][driverName] = {}
 			cls.core = cls.synth_driver_class()
 			cls.core.wv = cls.engine
 
 	@classmethod
 	def engineOff(cls):
 		if cls.core:
-			cls.core.terminate()
-			cls.core = None
+			try:
+				cls.core.terminate()
+			finally:
+				cls.core = None
 
 	def setCoreParameter(self):
 		if self.core:

--- a/addon/synthDrivers/WorldVoice/driver/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/__init__.py
@@ -1,5 +1,6 @@
 import config
 import languageHandler
+from logHandler import log
 from synthDriverHandler import getSynth
 
 from ..taskManager import CancellationToken
@@ -79,8 +80,20 @@ class Voice(object):
 
 	@property
 	def variants(self):
-		self._variants = []
-		return self._variants
+		if not self.core or "variant" not in self.__class__.supportedSettings():
+			return []
+		try:
+			availableVariants = self.core.availableVariants
+		except Exception:
+			return []
+		return [{
+			"id": str(getattr(variantInfo, "id", variantId)),
+			"name": (
+				getattr(variantInfo, "displayName", None)
+				or getattr(variantInfo, "name", None)
+				or str(variantInfo)
+			),
+		} for variantId, variantInfo in availableVariants.items()]
 
 	@property
 	def variant(self):
@@ -88,6 +101,19 @@ class Voice(object):
 
 	@variant.setter
 	def variant(self, value):
+		variantIds = [item["id"] for item in self.variants]
+		if not variantIds:
+			value = "default"
+		elif value not in variantIds:
+			value = variantIds[0]
+		if self.core and variantIds:
+			try:
+				if getattr(self.core, "voice", None) != self.id:
+					self.core.voice = self.id
+				self.core.variant = value
+			except Exception:
+				log.debugWarning(f"Unable to set variant for voice {self.name}", exc_info=True)
+				return
 		self._variant = value
 
 	@classmethod

--- a/addon/synthDrivers/WorldVoice/driver/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/__init__.py
@@ -1,8 +1,8 @@
-import time
-
 import config
 import languageHandler
 from synthDriverHandler import getSynth
+
+from ..taskManager import CancellationToken
 
 
 def boolean(value):
@@ -147,9 +147,12 @@ class Voice(object):
 		self.taskManager.add_speak_task(self, _speak)
 
 	def breaks(self, sec):
+		token = CancellationToken()
+
 		def _breaks():
-			time.sleep(sec)
-		self.taskManager.add_task(self, _breaks)
+			token.wait(max(0, sec))
+
+		self.taskManager.add_task(self, _breaks, token=token)
 
 	def stop(self):
 		self.core.cancel()

--- a/addon/synthDrivers/WorldVoice/sayAll.py
+++ b/addon/synthDrivers/WorldVoice/sayAll.py
@@ -36,7 +36,10 @@ def get_sayall_wait_factor():
 	if synth.name == 'WorldVoice':
 		wait_factor = synth._globalwaitfactor * synth.sayallwaitfactor
 	else:
-		if config.conf["WorldVoice"]["pipeline"]["enable"]:
+		if (
+			config.conf["WorldVoice"]["pipeline"]["enable"]
+			and config.conf["WorldVoice"]["pipeline"]["scope"] == "all"
+		):
 			wait_factor = config.conf["WorldVoice"]["pipeline"]["global_wait_factor"] // 10 * config.conf["WorldVoice"]["pipeline"]["sayall_wait_factor"]
 		else:
 			wait_factor = 0

--- a/addon/synthDrivers/WorldVoice/taskManager.py
+++ b/addon/synthDrivers/WorldVoice/taskManager.py
@@ -148,23 +148,26 @@ class TaskManager:
 			pass
 
 	def shutdown(self):
-		self.cancel()
-		self._stop.set()
-		self._q.put(None)
-		self._thread.join()
-
 		try:
-			synthIndexReached.unregister(IndexReached_notify_forward)
-		except Exception:
-			pass
-		try:
-			synthDoneSpeaking.unregister(DoneSpeaking_notify_forward)
-		except Exception:
-			pass
-		try:
-			synthDoneSpeaking.unregister(self._on_done_speaking)
-		except Exception:
-			pass
+			self.cancel()
+			self._stop.set()
+			self._q.put(None)
+			self._thread.join(timeout=2)
+			if self._thread.is_alive():
+				log.debugWarning("WorldVoice task manager worker did not stop in time")
+		finally:
+			try:
+				synthIndexReached.unregister(IndexReached_notify_forward)
+			except Exception:
+				pass
+			try:
+				synthDoneSpeaking.unregister(DoneSpeaking_notify_forward)
+			except Exception:
+				pass
+			try:
+				synthDoneSpeaking.unregister(self._on_done_speaking)
+			except Exception:
+				pass
 
 	# ----------------------------
 	# Worker

--- a/addon/synthDrivers/WorldVoice/voiceManager.py
+++ b/addon/synthDrivers/WorldVoice/voiceManager.py
@@ -88,12 +88,21 @@ class VoiceManager(object):
 		log.debug("Created voiceManager instance. Default voice is %s", default_meta.name)
 
 	def terminate(self):
-		for voiceName, instance in self._instanceCache.items():
-			instance.commit()
-			instance.close()
+		for voiceName, instance in list(self._instanceCache.items()):
+			try:
+				instance.commit()
+			except Exception:
+				log.error("voice %s commit error", voiceName, exc_info=True)
+			try:
+				instance.close()
+			except Exception:
+				log.error("voice %s close error", voiceName, exc_info=True)
 
 		for item in READY_ENGINE_CLASS.values():
-			item.engineOff()
+			try:
+				item.engineOff()
+			except Exception:
+				log.error("engine %s off error", getattr(item, "engine", item), exc_info=True)
 
 		self.taskManager = None
 

--- a/addon/synthDrivers/WorldVoice/voiceManager.py
+++ b/addon/synthDrivers/WorldVoice/voiceManager.py
@@ -118,12 +118,19 @@ class VoiceManager(object):
 	def waitfactor(self):
 		return self._waitfactor
 
+	def _setInstanceWaitfactor(self, voiceName, instance, value):
+		if not hasattr(type(instance), "waitfactor"):
+			return
+		try:
+			instance.waitfactor = value
+		except Exception:
+			log.debugWarning(f"Unable to set waitfactor for voice {voiceName}", exc_info=True)
+
 	@waitfactor.setter
 	def waitfactor(self, value):
 		self._waitfactor = value
 		for voiceName, instance in self._instanceCache.items():
-			if ("Cerence" in READY_ENGINE_CLASS and isinstance(instance, READY_ENGINE_CLASS["Cerence"])) or ("VE" in READY_ENGINE_CLASS and isinstance(instance, READY_ENGINE_CLASS["VE"])):
-				instance.waitfactor = value
+			self._setInstanceWaitfactor(voiceName, instance, value)
 
 	def _getDefaultVoiceMeta(self) -> VoiceMeta:
 		lang = languageHandler.getLanguage()
@@ -149,7 +156,7 @@ class VoiceManager(object):
 			taskManager=self.taskManager
 		)
 		voiceInstance.loadParameter()
-		voiceInstance.waitfactor = self.waitfactor
+		self._setInstanceWaitfactor(voiceInstance.name, voiceInstance, self.waitfactor)
 
 		self._instanceCache[voiceInstance.name] = voiceInstance
 		return voiceInstance


### PR DESCRIPTION
## Summary

This PR fixes pause handling, waitfactor targeting, variant validation, and WorldVoice shutdown when switching away from the synthesizer.

- Make WorldVoice `BreakCommand` pauses cancellable.
- Respect `pipeline.scope` before adding say-all pauses outside WorldVoice.
- Apply VE and Cerence waitfactor to the target native voice instance.
- Avoid assigning waitfactor to wrappers that do not support it.
- Validate variant values against the current wrapped voice, and expose native variants for wrappers that support them.
- Avoid keeping a stale variant value in wrapper state if the native variant update fails.
- Shut down the WorldVoice task manager and unregister forwarded synth notifications on termination.
- Continue tearing down other voices and engines if one wrapped engine fails to terminate.
- Initialize wrapped native synth settings by the native `SynthDriver.name`, which covers external engines such as Aisound.

## Root Cause

Pauses were implemented as blocking sleeps inside the speech task worker, so stop/cancel could not interrupt them. Say-all pause handling also ignored the configured pipeline scope outside WorldVoice.

VE and Cerence waitfactor was written through the shared core driver, which can target whichever native voice is currently selected rather than the wrapper instance being updated.

Variant was treated as a common WorldVoice parameter even when the current wrapped voice did not expose the same variant values. This allowed a value such as Cerence's `embedded-pro` to remain selected after switching to another engine such as IBM, where valid native variant ids are different.

When switching away from WorldVoice, task manager callbacks were left registered until process exit. A wrapped engine termination failure could also interrupt NVDA's synth switch path. External engines such as Aisound expose a WorldVoice engine label that differs from NVDA's synth driver name, so their native speech config section must be initialized by `SynthDriver.name`.

## Fix

The fix keeps pause cancellation inside the existing task queue model, scopes say-all pauses consistently, writes waitfactor to the intended native voice, validates variants per wrapped voice, and makes WorldVoice shutdown independent from any single wrapped engine terminating cleanly.
