### PR TITLE
Fix: Remove Byte String Formatting (b'...') from Cerence and VE Voice Labels

### DIFF
--- a/addon/synthDrivers/WorldVoice/driver/Cerence/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/Cerence/__init__.py
@@ -61,26 +61,17 @@ class Voice(Voice):
 		except Exception:
 			return result
 
-		# Helper to ensure we have a clean string
-		def clean_str(val):
-			# 1. If it's actually bytes, decode it
-			if isinstance(val, bytes):
-				return val.decode('utf-8', errors='ignore')
-			
-			# 2. Convert to string
-			s = str(val)
-			
-			# 3. The Brute Force: If the string literally starts with b' and ends with '
-			# This happens when another part of the code did str(bytes_object)
-			if s.startswith("b'") and s.endswith("'"):
-				return s[2:-1] # Strip the first two chars (b') and the last char (')
-				
-			return s
 		for voice in voices:
-			# Decode the raw properties from the voice object
-			v_id = clean_str(voice.id)
-			v_displayName = clean_str(voice.displayName)
-			localeName = clean_str(voice.language or "unknown")
+			# Decodes bytes AND strips literal b'...' prefixes if they exist
+			def fix(v):
+				s = v.decode('utf-8', 'ignore') if isinstance(v, bytes) else str(v)
+				return s.strip("b'").strip("'") if (s.startswith("b'") and s.endswith("'")) else s
+
+			v_id = fix(voice.id)
+			v_displayName = fix(voice.displayName)
+			
+			localeName = (voice.language or "unknown")
+			localeName = fix(localeName)
 			
 			langDescription = languageHandler.getLanguageDescription(localeName)
 			
@@ -90,8 +81,7 @@ class Voice(Voice):
 				else:
 					langDescription = localeName
 			
-			# Ensure langDescription itself is a clean string for formatting
-			langDescription = clean_str(langDescription)
+			langDescription = fix(langDescription)
 
 			result.append({
 				"id": v_id,
@@ -100,7 +90,7 @@ class Voice(Voice):
 				"language": localeName,
 				"langDescription": langDescription,
 				"description": "[%s] %s - %s" % (cls.engine, v_id, langDescription),
-				"engine": "Cerence",
+				"engine": cls.engine,
 			})
 
 		return result

--- a/addon/synthDrivers/WorldVoice/driver/Cerence/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/Cerence/__init__.py
@@ -61,22 +61,45 @@ class Voice(Voice):
 		except Exception:
 			return result
 
+		# Helper to ensure we have a clean string
+		def clean_str(val):
+			# 1. If it's actually bytes, decode it
+			if isinstance(val, bytes):
+				return val.decode('utf-8', errors='ignore')
+			
+			# 2. Convert to string
+			s = str(val)
+			
+			# 3. The Brute Force: If the string literally starts with b' and ends with '
+			# This happens when another part of the code did str(bytes_object)
+			if s.startswith("b'") and s.endswith("'"):
+				return s[2:-1] # Strip the first two chars (b') and the last char (')
+				
+			return s
 		for voice in voices:
-			localeName = voice.language or "unknown"
+			# Decode the raw properties from the voice object
+			v_id = clean_str(voice.id)
+			v_displayName = clean_str(voice.displayName)
+			localeName = clean_str(voice.language or "unknown")
+			
 			langDescription = languageHandler.getLanguageDescription(localeName)
+			
 			if not langDescription:
-				if " - " in voice.displayName:
-					langDescription = voice.displayName.split(" - ", 1)[1]
+				if " - " in v_displayName:
+					langDescription = v_displayName.split(" - ", 1)[1]
 				else:
 					langDescription = localeName
-			name = voice.id
+			
+			# Ensure langDescription itself is a clean string for formatting
+			langDescription = clean_str(langDescription)
+
 			result.append({
-				"id": name,
-				"name": name,
+				"id": v_id,
+				"name": v_id,
 				"locale": localeName,
 				"language": localeName,
 				"langDescription": langDescription,
-				"description": "[%s] %s - %s" % (cls.engine, name, langDescription),
+				"description": "[%s] %s - %s" % (cls.engine, v_id, langDescription),
 				"engine": "Cerence",
 			})
 

--- a/addon/synthDrivers/WorldVoice/driver/VE/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/VE/__init__.py
@@ -56,22 +56,45 @@ class Voice(Voice):
 		except Exception:
 			return result
 
+		# Helper to ensure we have a clean string
+		def clean_str(val):
+			# 1. If it's actually bytes, decode it
+			if isinstance(val, bytes):
+				return val.decode('utf-8', errors='ignore')
+			
+			# 2. Convert to string
+			s = str(val)
+			
+			# 3. The Brute Force: If the string literally starts with b' and ends with '
+			if s.startswith("b'") and s.endswith("'"):
+				return s[2:-1] 
+				
+			return s
+
 		for voice in voices:
-			localeName = voice.language or "unknown"
+			# Decode properties from the voice object
+			v_id = clean_str(voice.id)
+			v_displayName = clean_str(voice.displayName)
+			localeName = clean_str(voice.language or "unknown")
+			
 			langDescription = languageHandler.getLanguageDescription(localeName)
+			
 			if not langDescription:
-				if " - " in voice.displayName:
-					langDescription = voice.displayName.split(" - ", 1)[1]
+				if " - " in v_displayName:
+					langDescription = v_displayName.split(" - ", 1)[1]
 				else:
 					langDescription = localeName
-			name = voice.id
+			
+			# Clean the description before formatting
+			langDescription = clean_str(langDescription)
+
 			result.append({
-				"id": name,
-				"name": name,
+				"id": v_id,
+				"name": v_id,
 				"locale": localeName,
 				"language": localeName,
 				"langDescription": langDescription,
-				"description": "[%s] %s - %s" % (cls.engine, name, langDescription),
+				"description": "[%s] %s - %s" % (cls.engine, v_id, langDescription),
 				"engine": cls.engine,
 			})
 

--- a/addon/synthDrivers/WorldVoice/driver/VE/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/VE/__init__.py
@@ -56,26 +56,17 @@ class Voice(Voice):
 		except Exception:
 			return result
 
-		# Helper to ensure we have a clean string
-		def clean_str(val):
-			# 1. If it's actually bytes, decode it
-			if isinstance(val, bytes):
-				return val.decode('utf-8', errors='ignore')
-			
-			# 2. Convert to string
-			s = str(val)
-			
-			# 3. The Brute Force: If the string literally starts with b' and ends with '
-			if s.startswith("b'") and s.endswith("'"):
-				return s[2:-1] 
-				
-			return s
-
 		for voice in voices:
-			# Decode properties from the voice object
-			v_id = clean_str(voice.id)
-			v_displayName = clean_str(voice.displayName)
-			localeName = clean_str(voice.language or "unknown")
+			# Decodes bytes AND strips literal b'...' prefixes if they exist
+			def fix(v):
+				s = v.decode('utf-8', 'ignore') if isinstance(v, bytes) else str(v)
+				return s.strip("b'").strip("'") if (s.startswith("b'") and s.endswith("'")) else s
+
+			v_id = fix(voice.id)
+			v_displayName = fix(voice.displayName)
+			
+			localeName = (voice.language or "unknown")
+			localeName = fix(localeName)
 			
 			langDescription = languageHandler.getLanguageDescription(localeName)
 			
@@ -85,8 +76,7 @@ class Voice(Voice):
 				else:
 					langDescription = localeName
 			
-			# Clean the description before formatting
-			langDescription = clean_str(langDescription)
+			langDescription = fix(langDescription)
 
 			result.append({
 				"id": v_id,


### PR DESCRIPTION
### Summary
This PR resolves an issue in the NVDA voice selection list where voices for the Cerence and Vocalizer Expressive (VE) engines are displayed with a `b'...'` prefix for some voices (e.g., `[VE] Amira - b'Malay'`).

### The Fix
I've added a `clean_str` utility within the `voices()` method for both `cerence.py` and `ve.py`. This utility decodes raw bytes and surgically strips `b'...'` characters from strings where the byte representation was already converted to text. Ensures a clean, human-readable label for the NVDA Voice List.

### Contributor Note (AI-Assisted)
I am submitting this as a user of the add-on and do not have formal experience in coding. I relied entirely on `AI assistance` to diagnose the `byte-string` issue and to write the Python logic for the fix. I have verified the results on my `local machine` (Windows 11) and the voice labels are now displayed correctly. Please feel free to `refactor` or `rewrite` this code to better fit the project’s standards, as I am primarily focused on providing a working solution for the community.

### Visual Examples

#### Before This Fix
* `[Cerence] Amira - b'Malay'`
* `[Cerence] Feifei-Ml - b'Sichuanese'`

#### After This Fix
* `[Cerence] Amira - Malay`
* `[Cerence] Feifei-Ml - Sichuanese`