### PR TITLE
feat: add configurable pause after punctuation marks

### DIFF
--- a/addon/globalPlugins/WorldVoice/speechSettingsDialog.py
+++ b/addon/globalPlugins/WorldVoice/speechSettingsDialog.py
@@ -123,8 +123,9 @@ class SpeechPipelinePanel(SettingsPanel):
 		number_mode_label = [
 			_("value"),
 			_("number"),
+			_("pair"),
 		]
-		self.number_mode_value = ["value", "number"]
+		self.number_mode_value = ["value", "number", "pair"]
 
 		self._number_mode_choice = settingsSizerHelper.addLabeledControl(
 			_("Number mode:"),
@@ -144,6 +145,10 @@ class SpeechPipelinePanel(SettingsPanel):
 		self._number_wait_factor_slider = settingsSizerHelper.addLabeledControl(_("number wait factor:"), wx.Slider, value=50, minValue=0, maxValue=100, style=wx.SL_HORIZONTAL)
 		self.Bind(wx.EVT_SLIDER, self.onNumberWaitFactorSliderScroll, self._number_wait_factor_slider)
 		self._number_wait_factor_slider.SetValue(pipeline_settings.number_wait_factor)
+
+		self._pair_wait_factor_slider = settingsSizerHelper.addLabeledControl(_("pair wait factor:"), wx.Slider, value=50, minValue=0, maxValue=100, style=wx.SL_HORIZONTAL)
+		self.Bind(wx.EVT_SLIDER, self.onPairWaitFactorSliderScroll, self._pair_wait_factor_slider)
+		self._pair_wait_factor_slider.SetValue(pipeline_settings.pair_wait_factor)
 
 		self._item_wait_factor_slider = settingsSizerHelper.addLabeledControl(_("item wait factor:"), wx.Slider, value=50, minValue=0, maxValue=100, style=wx.SL_HORIZONTAL)
 		self.Bind(wx.EVT_SLIDER, self.onItemWaitFactorSliderScroll, self._item_wait_factor_slider)
@@ -187,6 +192,7 @@ class SpeechPipelinePanel(SettingsPanel):
 			punctuation_wait_factor=self._punctuation_wait_factor_slider.GetValue(),
 			punctuation_pause_enabled=self._punctuation_pause_enabled_checkbox.GetValue(),
 			punctuation_pause_characters=self._punctuation_pause_characters_edit.GetValue(),
+			pair_wait_factor=self._pair_wait_factor_slider.GetValue(),
 		)
 		apply_global_pipeline_scope(settings, getSynth().name)
 
@@ -197,6 +203,9 @@ class SpeechPipelinePanel(SettingsPanel):
 		pass
 
 	def onNumberWaitFactorSliderScroll(self, event):
+		pass
+
+	def onPairWaitFactorSliderScroll(self, event):
 		pass
 
 	def onItemWaitFactorSliderScroll(self, event):
@@ -221,6 +230,7 @@ class SpeechPipelinePanel(SettingsPanel):
 		self._number_mode_choice.Enable()
 		self._global_wait_factor_slider.Enable()
 		self._number_wait_factor_slider.Enable()
+		self._pair_wait_factor_slider.Enable()
 		self._item_wait_factor_slider.Enable()
 		self._sayall_wait_factor_slider.Enable()
 		self._chinesespace_wait_factor_slider.Enable()
@@ -234,6 +244,7 @@ class SpeechPipelinePanel(SettingsPanel):
 		self._number_mode_choice.Disable()
 		self._global_wait_factor_slider.Disable()
 		self._number_wait_factor_slider.Disable()
+		self._pair_wait_factor_slider.Disable()
 		self._item_wait_factor_slider.Disable()
 		self._sayall_wait_factor_slider.Disable()
 		self._chinesespace_wait_factor_slider.Disable()
@@ -254,6 +265,7 @@ class SpeechPipelinePanel(SettingsPanel):
 			punctuation_wait_factor=self._punctuation_wait_factor_slider.GetValue(),
 			punctuation_pause_enabled=self._punctuation_pause_enabled_checkbox.GetValue(),
 			punctuation_pause_characters=self._punctuation_pause_characters_edit.GetValue(),
+			pair_wait_factor=self._pair_wait_factor_slider.GetValue(),
 		)
 		save_pipeline_settings(settings)
 

--- a/addon/globalPlugins/WorldVoice/speechSettingsDialog.py
+++ b/addon/globalPlugins/WorldVoice/speechSettingsDialog.py
@@ -157,6 +157,22 @@ class SpeechPipelinePanel(SettingsPanel):
 		self.Bind(wx.EVT_SLIDER, self.onChinesespaceWaitFactorSliderScroll, self._chinesespace_wait_factor_slider)
 		self._chinesespace_wait_factor_slider.SetValue(pipeline_settings.chinesespace_wait_factor)
 
+		self._punctuation_pause_enabled_checkbox = wx.CheckBox(
+			self,
+			label=_("Enable punctuation pause control")
+		)
+		settingsSizerHelper.addItem(self._punctuation_pause_enabled_checkbox)
+		self.Bind(wx.EVT_CHECKBOX, self.onPunctuationPauseEnabledChange, self._punctuation_pause_enabled_checkbox)
+		self._punctuation_pause_enabled_checkbox.SetValue(pipeline_settings.punctuation_pause_enabled)
+
+		self._punctuation_wait_factor_slider = settingsSizerHelper.addLabeledControl(_("punctuation wait factor:"), wx.Slider, value=50, minValue=0, maxValue=100, style=wx.SL_HORIZONTAL)
+		self.Bind(wx.EVT_SLIDER, self.onPunctuationWaitFactorSliderScroll, self._punctuation_wait_factor_slider)
+		self._punctuation_wait_factor_slider.SetValue(pipeline_settings.punctuation_wait_factor)
+
+		self._punctuation_pause_characters_edit = settingsSizerHelper.addLabeledControl(_("Punctuation pause characters:"), wx.TextCtrl)
+		self._punctuation_pause_characters_edit.SetValue(pipeline_settings.punctuation_pause_characters)
+		self.onPunctuationPauseEnabledChange(None)
+
 	def onScopeSelectionChange(self, event):
 		value = self._scope_value[self._scope_choice.GetCurrentSelection()]
 		settings = PipelineSettings(
@@ -168,6 +184,9 @@ class SpeechPipelinePanel(SettingsPanel):
 			item_wait_factor=self._item_wait_factor_slider.GetValue(),
 			sayall_wait_factor=self._sayall_wait_factor_slider.GetValue(),
 			chinesespace_wait_factor=self._chinesespace_wait_factor_slider.GetValue(),
+			punctuation_wait_factor=self._punctuation_wait_factor_slider.GetValue(),
+			punctuation_pause_enabled=self._punctuation_pause_enabled_checkbox.GetValue(),
+			punctuation_pause_characters=self._punctuation_pause_characters_edit.GetValue(),
 		)
 		apply_global_pipeline_scope(settings, getSynth().name)
 
@@ -189,6 +208,14 @@ class SpeechPipelinePanel(SettingsPanel):
 	def onChinesespaceWaitFactorSliderScroll(self, event):
 		pass
 
+	def onPunctuationPauseEnabledChange(self, event):
+		enabled = self._punctuation_pause_enabled_checkbox.GetValue()
+		self._punctuation_wait_factor_slider.Enable(enabled)
+		self._punctuation_pause_characters_edit.Enable(enabled)
+
+	def onPunctuationWaitFactorSliderScroll(self, event):
+		pass
+
 	def sliderEnable(self):
 		self._ignore_comma_between_number_checkbox.Enable()
 		self._number_mode_choice.Enable()
@@ -197,6 +224,10 @@ class SpeechPipelinePanel(SettingsPanel):
 		self._item_wait_factor_slider.Enable()
 		self._sayall_wait_factor_slider.Enable()
 		self._chinesespace_wait_factor_slider.Enable()
+		self._punctuation_pause_enabled_checkbox.Enable()
+		if self._punctuation_pause_enabled_checkbox.GetValue():
+			self._punctuation_wait_factor_slider.Enable()
+			self._punctuation_pause_characters_edit.Enable()
 
 	def sliderDisable(self):
 		self._ignore_comma_between_number_checkbox.Disable()
@@ -206,6 +237,9 @@ class SpeechPipelinePanel(SettingsPanel):
 		self._item_wait_factor_slider.Disable()
 		self._sayall_wait_factor_slider.Disable()
 		self._chinesespace_wait_factor_slider.Disable()
+		self._punctuation_pause_enabled_checkbox.Disable()
+		self._punctuation_wait_factor_slider.Disable()
+		self._punctuation_pause_characters_edit.Disable()
 
 	def onSave(self):
 		settings = PipelineSettings(
@@ -217,6 +251,9 @@ class SpeechPipelinePanel(SettingsPanel):
 			item_wait_factor=self._item_wait_factor_slider.GetValue(),
 			sayall_wait_factor=self._sayall_wait_factor_slider.GetValue(),
 			chinesespace_wait_factor=self._chinesespace_wait_factor_slider.GetValue(),
+			punctuation_wait_factor=self._punctuation_wait_factor_slider.GetValue(),
+			punctuation_pause_enabled=self._punctuation_pause_enabled_checkbox.GetValue(),
+			punctuation_pause_characters=self._punctuation_pause_characters_edit.GetValue(),
 		)
 		save_pipeline_settings(settings)
 

--- a/addon/synthDrivers/WorldVoice/VoiceSettingsDialogs.py
+++ b/addon/synthDrivers/WorldVoice/VoiceSettingsDialogs.py
@@ -18,6 +18,36 @@ class WorldVoiceVoiceSettingsPanel(VoiceSettingsPanel):
 		self.createDriverSettings()
 		super().makeSettings(settingsSizer)
 		self._addPunctuationPauseCharactersControl(settingsSizer)
+		self._bindPunctuationPauseEnabledToggle()
+
+	def _bindPunctuationPauseEnabledToggle(self):
+		"""
+		Hook the "Enable punctuation pause control" checkbox so the
+		"Punctuation wait factor" slider is hidden while the feature is
+		disabled, mirroring the initial state on dialog open.
+		"""
+		checkbox = getattr(self, "punctuationpauseenabledCheckbox", None)
+		sliderSizer = self.sizerDict.get("punctuationwaitfactor")
+		if checkbox is None or sliderSizer is None:
+			return
+		checkbox.Bind(wx.EVT_CHECKBOX, self._onPunctuationPauseEnabledToggle)
+		self._applyPunctuationWaitFactorVisibility()
+
+	def _onPunctuationPauseEnabledToggle(self, evt):
+		evt.Skip()
+		setattr(self._getSettingsStorage(), "punctuationpauseenabled", evt.IsChecked())
+		self._applyPunctuationWaitFactorVisibility()
+
+	def _applyPunctuationWaitFactorVisibility(self):
+		checkbox = getattr(self, "punctuationpauseenabledCheckbox", None)
+		sliderSizer = self.sizerDict.get("punctuationwaitfactor")
+		if checkbox is None or sliderSizer is None:
+			return
+		if checkbox.GetValue():
+			self.settingsSizer.Show(sliderSizer)
+		else:
+			self.settingsSizer.Hide(sliderSizer)
+		self.settingsSizer.Layout()
 
 	def _addPunctuationPauseCharactersControl(self, settingsSizer):
 		settingsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)

--- a/addon/synthDrivers/WorldVoice/VoiceSettingsDialogs.py
+++ b/addon/synthDrivers/WorldVoice/VoiceSettingsDialogs.py
@@ -1,13 +1,41 @@
+import addonHandler
 from autoSettingsUtils.driverSetting import BooleanDriverSetting, NumericDriverSetting
+import config
 import gui
+from gui import guiHelper
 from gui.settingsDialogs import VoiceSettingsPanel
 from logHandler import log
+import wx
+
+from .pipeline.settings import DEFAULT_PIPELINE_SETTINGS
+
+
+addonHandler.initTranslation()
 
 
 class WorldVoiceVoiceSettingsPanel(VoiceSettingsPanel):
 	def makeSettings(self, settingsSizer):
 		self.createDriverSettings()
 		super().makeSettings(settingsSizer)
+		self._addPunctuationPauseCharactersControl(settingsSizer)
+
+	def _addPunctuationPauseCharactersControl(self, settingsSizer):
+		settingsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
+		self.punctuationPauseCharactersEdit = settingsSizerHelper.addLabeledControl(
+			_("Punctuation pause characters:"),
+			wx.TextCtrl,
+		)
+		self.punctuationPauseCharactersEdit.SetValue(
+			config.conf["WorldVoice"]["pipeline"].get(
+				"punctuation_pause_characters",
+				DEFAULT_PIPELINE_SETTINGS["punctuation_pause_characters"],
+			)
+		)
+
+	def onSave(self):
+		value = self.punctuationPauseCharactersEdit.GetValue().strip()
+		config.conf["WorldVoice"]["pipeline"]["punctuation_pause_characters"] = value
+		super().onSave()
 
 	def createDriverSettings(self, changedSetting=None):
 		"""

--- a/addon/synthDrivers/WorldVoice/__init__.py
+++ b/addon/synthDrivers/WorldVoice/__init__.py
@@ -24,6 +24,7 @@ from .engine import READY_ENGINE_CLASS
 from .pipeline import (
 	ignore_comma_between_number,
 	item_wait_factor,
+	inject_punctuation_pause,
 	inject_langchange_reorder,
 	deduplicate_language_command,
 	lang_cmd_to_voice,
@@ -71,6 +72,8 @@ config.conf.spec["WorldVoice"] = {
 		"item_wait_factor": "integer(default=10,min=0,max=100)",
 		"sayall_wait_factor": "integer(default=10,min=0,max=100)",
 		"chinesespace_wait_factor": "integer(default=10,min=0,max=100)",
+		"punctuation_wait_factor": "integer(default=0,min=0,max=100)",
+		"punctuation_pause_characters": "string(default=\"،؛,.;:!؟?…\")",
 	},
 	"role": {},
 	"engine": {
@@ -84,6 +87,8 @@ config.conf.spec["WorldVoice"] = {
 		"number_wait_factor": "boolean(default=false)",
 		"item_wait_factor": "boolean(default=false)",
 		"chinesespace_wait_factor": "boolean(default=false)",
+		"punctuation_wait_factor": "boolean(default=false)",
+		"remove_silence": "boolean(default=false)",
 		"speech_viewer": "boolean(default=false)",
 		"apply_speech_dictionaries": "boolean(default=false)",
 	},
@@ -202,6 +207,14 @@ class SynthDriver(SynthDriver):
 				"chinesespacewaitfactor",
 				# Translators: Label for a setting in voice settings dialog.
 				_("Chinese space wait factor"),
+				availableInSettingsRing=True,
+				defaultVal=0,
+				minStep=1,
+			),
+			NumericDriverSetting(
+				"punctuationwaitfactor",
+				# Translators: Label for a setting in voice settings dialog.
+				_("Punctuation wait factor"),
 				availableInSettingsRing=True,
 				defaultVal=0,
 				minStep=1,
@@ -610,6 +623,20 @@ class SynthDriver(SynthDriver):
 	def _set_chinesespacewaitfactor(self, value):
 		self._chinesespacewaitfactor = value
 		config.conf["WorldVoice"]["pipeline"]["chinesespace_wait_factor"] = self.chinesespacewaitfactor
+
+	def _get_punctuationwaitfactor(self):
+		# Defensive: the attribute may not exist yet when the driver was
+		# upgraded from a version without this setting.
+		return getattr(self, "_punctuationwaitfactor", 0)
+
+	def _set_punctuationwaitfactor(self, value):
+		self._punctuationwaitfactor = value
+		if value > 0:
+			filter_speechSequence.register(inject_punctuation_pause)
+			order_move_to_start_register()
+		else:
+			filter_speechSequence.unregister(inject_punctuation_pause)
+		config.conf["WorldVoice"]["pipeline"]["punctuation_wait_factor"] = self.punctuationwaitfactor
 
 	def patchedLengthSpeechSequence(self, speechSequence):
 		result = []

--- a/addon/synthDrivers/WorldVoice/__init__.py
+++ b/addon/synthDrivers/WorldVoice/__init__.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 import importlib
 import os
-import re
 import sys
 import time
 from typing import Any
@@ -37,7 +36,6 @@ from .pipeline.settings import (
 	get_effective_pipeline_settings,
 	save_pipeline_settings,
 )
-from ._speechcommand import SplitCommand
 from .taskManager import TaskManager
 from .driver import Voice
 from .voiceManager import VoiceManager
@@ -700,31 +698,6 @@ class SynthDriver(SynthDriver):
 		else:
 			filter_speechSequence.unregister(inject_punctuation_pause)
 		config.conf["WorldVoice"]["pipeline"]["punctuation_wait_factor"] = self.punctuationwaitfactor
-
-	def patchedLengthSpeechSequence(self, speechSequence):
-		result = []
-		for command in speechSequence:
-			if isinstance(command, str):
-				result.extend(self.lengthsplit(command, 100))
-			else:
-				result.append(command)
-		return result
-
-	def lengthsplit(self, string, length):
-		result = []
-		pattern = re.compile(r"[\s]")
-		spaces = pattern.findall(string)
-		others = pattern.split(string)
-		fragment = ""
-		for other, space in zip(others, spaces):
-			fragment += other + space
-			if len(fragment) > length:
-				result.append(fragment)
-				result.append(SplitCommand())
-				fragment = ""
-		fragment += others[-1]
-		result.append(fragment)
-		return result
 
 	def _getLocaleReadableName(self, locale):
 		description = languageHandler.getLanguageDescription(locale)

--- a/addon/synthDrivers/WorldVoice/__init__.py
+++ b/addon/synthDrivers/WorldVoice/__init__.py
@@ -69,6 +69,7 @@ config.conf.spec["WorldVoice"] = {
 		"number_mode": "string(default=value)",
 		"global_wait_factor": "integer(default=10,min=0,max=100)",
 		"number_wait_factor": "integer(default=10,min=0,max=100)",
+		"pair_wait_factor": "integer(default=0,min=0,max=100)",
 		"item_wait_factor": "integer(default=10,min=0,max=100)",
 		"sayall_wait_factor": "integer(default=10,min=0,max=100)",
 		"chinesespace_wait_factor": "integer(default=10,min=0,max=100)",
@@ -189,6 +190,14 @@ class SynthDriver(SynthDriver):
 				minStep=1,
 			),
 			NumericDriverSetting(
+				"pairwaitfactor",
+				# Translators: Label for a setting in voice settings dialog.
+				_("Pair wait factor"),
+				availableInSettingsRing=True,
+				defaultVal=0,
+				minStep=1,
+			),
+			NumericDriverSetting(
 				"itemwaitfactor",
 				# Translators: Label for a setting in voice settings dialog.
 				_("item wait factor"),
@@ -284,6 +293,14 @@ class SynthDriver(SynthDriver):
 				"numberwaitfactor",
 				# Translators: Label for a setting in voice settings dialog.
 				_("Number wait factor"),
+				availableInSettingsRing=True,
+				defaultVal=0,
+				minStep=1,
+			),
+			NumericDriverSetting(
+				"pairwaitfactor",
+				# Translators: Label for a setting in voice settings dialog.
+				_("Pair wait factor"),
 				availableInSettingsRing=True,
 				defaultVal=0,
 				minStep=1,
@@ -601,6 +618,7 @@ class SynthDriver(SynthDriver):
 		return dict({
 			"value": StringParameterInfo("value", _("value")),
 			"number": StringParameterInfo("number", _("number")),
+			"pair": StringParameterInfo("pair", _("pair")),
 		})
 
 	def _get_nummod(self):
@@ -624,6 +642,15 @@ class SynthDriver(SynthDriver):
 	def _set_numberwaitfactor(self, value):
 		self._numberwaitfactor = value
 		config.conf["WorldVoice"]["pipeline"]["number_wait_factor"] = self.numberwaitfactor
+
+	def _get_pairwaitfactor(self):
+		# Defensive: the attribute may not exist yet when the driver was
+		# upgraded from a version without this setting.
+		return getattr(self, "_pairwaitfactor", 0)
+
+	def _set_pairwaitfactor(self, value):
+		self._pairwaitfactor = value
+		config.conf["WorldVoice"]["pipeline"]["pair_wait_factor"] = self.pairwaitfactor
 
 	def _get_itemwaitfactor(self):
 		return self._itemwaitfactor

--- a/addon/synthDrivers/WorldVoice/__init__.py
+++ b/addon/synthDrivers/WorldVoice/__init__.py
@@ -73,6 +73,7 @@ config.conf.spec["WorldVoice"] = {
 		"sayall_wait_factor": "integer(default=10,min=0,max=100)",
 		"chinesespace_wait_factor": "integer(default=10,min=0,max=100)",
 		"punctuation_wait_factor": "integer(default=0,min=0,max=100)",
+		"punctuation_pause_enabled": "boolean(default=true)",
 		"punctuation_pause_characters": "string(default=\"،؛,.;:!؟?…\")",
 	},
 	"role": {},
@@ -211,6 +212,15 @@ class SynthDriver(SynthDriver):
 				defaultVal=0,
 				minStep=1,
 			),
+			BooleanDriverSetting(
+				"punctuationpauseenabled",
+				# Translators: Label for a setting in voice settings dialog.
+				_("Enable punctuation pause control"),
+				availableInSettingsRing=True,
+				defaultVal=True,
+				# Translators: Label for a setting in synth settings ring.
+				displayName=_("Punctuation pauses"),
+			),
 			NumericDriverSetting(
 				"punctuationwaitfactor",
 				# Translators: Label for a setting in voice settings dialog.
@@ -298,6 +308,23 @@ class SynthDriver(SynthDriver):
 				"chinesespacewaitfactor",
 				# Translators: Label for a setting in voice settings dialog.
 				_("Chinese space wait factor"),
+				availableInSettingsRing=True,
+				defaultVal=0,
+				minStep=1,
+			),
+			BooleanDriverSetting(
+				"punctuationpauseenabled",
+				# Translators: Label for a setting in voice settings dialog.
+				_("Enable punctuation pause control"),
+				availableInSettingsRing=True,
+				defaultVal=True,
+				# Translators: Label for a setting in synth settings ring.
+				displayName=_("Punctuation pauses"),
+			),
+			NumericDriverSetting(
+				"punctuationwaitfactor",
+				# Translators: Label for a setting in voice settings dialog.
+				_("Punctuation wait factor"),
 				availableInSettingsRing=True,
 				defaultVal=0,
 				minStep=1,
@@ -623,6 +650,15 @@ class SynthDriver(SynthDriver):
 	def _set_chinesespacewaitfactor(self, value):
 		self._chinesespacewaitfactor = value
 		config.conf["WorldVoice"]["pipeline"]["chinesespace_wait_factor"] = self.chinesespacewaitfactor
+
+	def _get_punctuationpauseenabled(self):
+		# Defensive: the attribute may not exist yet when the driver was
+		# upgraded from a version without this setting.
+		return getattr(self, "_punctuationpauseenabled", True)
+
+	def _set_punctuationpauseenabled(self, value):
+		self._punctuationpauseenabled = value
+		config.conf["WorldVoice"]["pipeline"]["punctuation_pause_enabled"] = self.punctuationpauseenabled
 
 	def _get_punctuationwaitfactor(self):
 		# Defensive: the attribute may not exist yet when the driver was

--- a/addon/synthDrivers/WorldVoice/driver/Cerence/driver/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/Cerence/driver/__init__.py
@@ -20,7 +20,7 @@ from logHandler import log
 
 from . import ttsapi
 from .ttsapi.veTypes import *
-from synthDrivers.WorldVoice.driver.chunker import split_speech_text_pieces
+from synthDrivers.WorldVoice.driver.chunker import split_speech_text_pieces, break_repeated_runs
 
 addonHandler.initTranslation()
 
@@ -396,6 +396,7 @@ class SynthDriver(SynthDriver):
 
 	def _speak(self, voiceInstance, chunks):
 		text = "".join(chunks)
+		text = break_repeated_runs(text)
 		self._isSilence.clear()
 		for piece in split_speech_text_pieces(text):
 			ProcessText2Speech(voiceInstance, piece)()

--- a/addon/synthDrivers/WorldVoice/driver/Cerence/driver/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/Cerence/driver/__init__.py
@@ -20,6 +20,7 @@ from logHandler import log
 
 from . import ttsapi
 from .ttsapi.veTypes import *
+from synthDrivers.WorldVoice.driver.chunker import split_speech_text_pieces
 
 addonHandler.initTranslation()
 
@@ -396,7 +397,8 @@ class SynthDriver(SynthDriver):
 	def _speak(self, voiceInstance, chunks):
 		text = "".join(chunks)
 		self._isSilence.clear()
-		ProcessText2Speech(voiceInstance, text)()
+		for piece in split_speech_text_pieces(text):
+			ProcessText2Speech(voiceInstance, piece)()
 
 	def cancel(self):
 		self._isSilence.set()

--- a/addon/synthDrivers/WorldVoice/driver/VE/driver/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/VE/driver/__init__.py
@@ -20,7 +20,7 @@ from logHandler import log
 
 from . import ve2
 from .ve2.veTypes import *
-from synthDrivers.WorldVoice.driver.chunker import split_speech_text_pieces
+from synthDrivers.WorldVoice.driver.chunker import split_speech_text_pieces, break_repeated_runs
 
 addonHandler.initTranslation()
 
@@ -412,6 +412,7 @@ class SynthDriver(SynthDriver):
 
 	def _speak(self, voiceInstance, chunks):
 		text = "".join(chunks)
+		text = break_repeated_runs(text)
 		self._isSilence.clear()
 		for piece in split_speech_text_pieces(text):
 			ProcessText2Speech(voiceInstance, piece)()

--- a/addon/synthDrivers/WorldVoice/driver/VE/driver/__init__.py
+++ b/addon/synthDrivers/WorldVoice/driver/VE/driver/__init__.py
@@ -20,6 +20,7 @@ from logHandler import log
 
 from . import ve2
 from .ve2.veTypes import *
+from synthDrivers.WorldVoice.driver.chunker import split_speech_text_pieces
 
 addonHandler.initTranslation()
 
@@ -412,7 +413,8 @@ class SynthDriver(SynthDriver):
 	def _speak(self, voiceInstance, chunks):
 		text = "".join(chunks)
 		self._isSilence.clear()
-		ProcessText2Speech(voiceInstance, text)()
+		for piece in split_speech_text_pieces(text):
+			ProcessText2Speech(voiceInstance, piece)()
 
 	def cancel(self):
 		self._isSilence.set()

--- a/addon/synthDrivers/WorldVoice/driver/chunker.py
+++ b/addon/synthDrivers/WorldVoice/driver/chunker.py
@@ -11,6 +11,16 @@ MAX_TEXT_LENGTH = 100
 # Vocalizer control escape: ESC + backslash + content + backslash.
 _ESCAPE_RE = re.compile(r"\x1b\\.*?\\")
 
+# A run of this many identical Arabic letters is considered pathological.
+# Vocalizer Arabic text analysis slows down sharply on unbroken runs of 4 or
+# more identical letters, so runs longer than this get broken with spaces.
+MAX_REPEATED_RUN = 3
+
+# Arabic script code points where repeated-letter runs trigger the slow
+# analysis path: Arabic, Arabic Supplement, Arabic Extended-A, Arabic
+# Presentation Forms-A and -B.
+_ARABIC_LETTER = "[\\u0600-\\u06ff\\u0750-\\u077f\\u08a0-\\u08ff\\ufb50-\\ufdff\\ufe70-\\ufeff]"
+
 
 def split_speech_text_pieces(text, max_length=MAX_TEXT_LENGTH):
 	"""Split *text* into pieces of at most *max_length* plain characters.
@@ -62,3 +72,32 @@ def split_speech_text_pieces(text, max_length=MAX_TEXT_LENGTH):
 	if current:
 		pieces.append(current)
 	return pieces
+
+
+def break_repeated_runs(text, max_run=MAX_REPEATED_RUN):
+	"""Break runs of identical Arabic letters longer than *max_run*.
+
+	Vocalizer Arabic text analysis slows down sharply (seconds of silence
+	before any audio) when the input contains an unbroken run of 4 or more
+	identical Arabic letters, regardless of surrounding word boundaries.
+	Inserting a space after every *max_run* letters turns such a run into
+	separate word tokens which the engine analyzes normally; the inserted
+	space is inaudible in Arabic speech. Control escape sequences are left
+	untouched. Returns *text* unchanged when there is nothing to break.
+	"""
+	if max_run < 3 or not text:
+		return text
+	pattern = re.compile(rf"({_ARABIC_LETTER})\1{{{max_run},}}")
+
+	def _repl(match):
+		run = match.group(0)
+		return " ".join(run[i:i + max_run] for i in range(0, len(run), max_run))
+
+	parts = []
+	pos = 0
+	for match in _ESCAPE_RE.finditer(text):
+		parts.append(pattern.sub(_repl, text[pos:match.start()]))
+		parts.append(match.group())
+		pos = match.end()
+	parts.append(pattern.sub(_repl, text[pos:]))
+	return "".join(parts)

--- a/addon/synthDrivers/WorldVoice/driver/chunker.py
+++ b/addon/synthDrivers/WorldVoice/driver/chunker.py
@@ -1,0 +1,64 @@
+# A part of the WorldVoice add-on.
+# Split long speech text into smaller pieces so that speech synthesis
+# engines never receive an oversized text in a single call.
+
+import re
+
+# Maximum number of plain characters per piece. Control escape sequences
+# (e.g. \x1b\pause=100\) may make a piece slightly longer than this.
+MAX_TEXT_LENGTH = 100
+
+# Vocalizer control escape: ESC + backslash + content + backslash.
+_ESCAPE_RE = re.compile(r"\x1b\\.*?\\")
+
+
+def split_speech_text_pieces(text, max_length=MAX_TEXT_LENGTH):
+	"""Split *text* into pieces of at most *max_length* plain characters.
+
+	Pieces are split at whitespace boundaries when possible, otherwise at
+	character boundaries. Control escape sequences are never split and stay
+	attached to a single piece. Concatenating all returned pieces in order
+	reproduces the original *text*.
+	"""
+	if not text:
+		return []
+	if len(text) <= max_length:
+		return [text]
+	pieces = []
+	current = ""
+	pos = 0
+	tokens = []
+	for match in _ESCAPE_RE.finditer(text):
+		if match.start() > pos:
+			tokens.append(text[pos:match.start()])
+		tokens.append(match.group())
+		pos = match.end()
+	if pos < len(text):
+		tokens.append(text[pos:])
+	for token in tokens:
+		if token.startswith("\x1b"):
+			current += token
+			continue
+		while token:
+			remaining = max_length - len(current)
+			if remaining <= 0:
+				pieces.append(current)
+				current = ""
+				remaining = max_length
+			if len(token) <= remaining:
+				current += token
+				token = ""
+			else:
+				head = token[:remaining]
+				cut = head.rfind(" ")
+				if cut <= 0:
+					cut = remaining
+				else:
+					cut += 1
+				current += token[:cut]
+				token = token[cut:]
+				pieces.append(current)
+				current = ""
+	if current:
+		pieces.append(current)
+	return pieces

--- a/addon/synthDrivers/WorldVoice/pipeline/__init__.py
+++ b/addon/synthDrivers/WorldVoice/pipeline/__init__.py
@@ -48,8 +48,8 @@ def with_speech_sequence_log(label: str):
 	def decorator(func):
 		@wraps(func)
 		def wrapper(speechSequence):
-			_id = uuid.uuid4().hex
 			if (config.conf["general"]["loggingLevel"] == "DEBUG" or config.conf["WorldVoice"]["log"]["enable"]) and config.conf["WorldVoice"]["log"][label]:
+				_id = uuid.uuid4().hex
 				speechSequence = list(speechSequence)
 				if config.conf["general"]["loggingLevel"] == "DEBUG":
 					log.debug(f"speech sequence before {label} pipeline: {speechSequence}")
@@ -122,6 +122,16 @@ def get_number_wait_factor():
 def get_chinesespace_wait_factor():
 	settings = get_effective_pipeline_settings()
 	return settings.scaled_chinesespace_wait()
+
+
+def get_punctuation_wait_factor():
+	settings = get_effective_pipeline_settings()
+	return settings.scaled_punctuation_wait()
+
+
+def get_punctuation_pause_chars():
+	settings = get_effective_pipeline_settings()
+	return settings.punctuation_pause_characters.strip()
 
 
 # @with_order_log("speech_view")
@@ -351,6 +361,13 @@ def inject_number_language(
 ) -> Iterator[SpeechCmd]:
 	synth = getSynth()
 	if hasattr(synth, "_voiceManager"):
+		if synth._numlan == "default":
+			# The number-language wrapper commands are always dropped by
+			# deduplicate_language_command in this case, so the pass-through
+			# below is behavior-identical and avoids scanning every string
+			# for numbers.
+			yield from speechSequence
+			return
 		speechSequence = _insert_WVLangChangeCommand_between_number(speechSequence)
 		yield from speechSequence
 		return
@@ -465,6 +482,166 @@ def inject_chinese_space_pause(
 			yield item[pos:]
 
 
+_PUNCTUATION_RE_CACHE: dict[str, re.Pattern] = {}
+_PUNCTUATION_REMOVAL_RE_CACHE: dict[str, re.Pattern] = {}
+
+
+def _get_punctuation_regex(chars: str) -> re.Pattern:
+	regex = _PUNCTUATION_RE_CACHE.get(chars)
+	if regex is None:
+		# A punctuation run (one or more configured marks in a row) is only
+		# treated as a pause point when it is not directly surrounded by
+		# digits, so "12,500" and "3.5" are left untouched.
+		regex = re.compile(rf"(?<![0-9])[{re.escape(chars)}]+(?!\d)")
+		_PUNCTUATION_RE_CACHE[chars] = regex
+	return regex
+
+
+def _get_punctuation_removal_regex(chars: str) -> re.Pattern:
+	regex = _PUNCTUATION_REMOVAL_RE_CACHE.get(chars)
+	if regex is None:
+		# Unlike the pause-detection regex above, the lookbehind guard is
+		# omitted on purpose: a mark directly preceded by a digit may still be
+		# a sentence ending (e.g. the trailing period in "I have 5.") and must
+		# be removed. The lookahead alone protects real decimals such as
+		# "3.5" and thousands separators such as "12,500".
+		regex = re.compile(rf"[{re.escape(chars)}]+(?!\d)")
+		_PUNCTUATION_REMOVAL_RE_CACHE[chars] = regex
+	return regex
+
+
+def _split_punctuation_segments(
+		text: str,
+		regex: re.Pattern,
+) -> Iterator[tuple[str, str]]:
+	"""
+	Split *text* into ("text"|"punct", value) segments.
+
+	Consecutive punctuation marks form a single "punct" segment, and any
+	punctuation run surrounded by digits (e.g. the comma in "12,500" or the
+	dot in "3.5") is part of a "text" segment.
+	"""
+	pos = 0
+	for match in regex.finditer(text):
+		if match.start() > pos:
+			yield ("text", text[pos:match.start()])
+		yield ("punct", match.group())
+		pos = match.end()
+	if pos < len(text):
+		yield ("text", text[pos:])
+
+
+# @with_order_log("punctuation_wait_factor")
+@with_speech_sequence_log("punctuation_wait_factor")
+def inject_punctuation_pause(
+		speechSequence: Iterable[SpeechCmd],
+) -> Iterator[SpeechCmd]:
+	"""
+	Insert a short BreakCommand after a punctuation mark so the TTS does not
+	run the text following the punctuation straight into it.
+
+	* Works both between consecutive text items and *inside* a single text
+	  item, because a screen reader usually sends a whole sentence as one
+	  command.
+	* Consecutive punctuation marks count as a single pause point, and
+	  numeric punctuation such as the comma in "12,500" is skipped.
+	* The pause is only inserted when real text follows, and never as the
+	  last command of a sequence, so the voice cannot fall silent at the end.
+	* The pause length is capped (see PipelineSettings.scaled_punctuation_wait),
+	  so the voice never stops for a long silence at punctuation no matter how
+	  high the configured factor is.
+	* An existing BreakCommand between two text items suppresses this pause,
+	  so the punctuation pause and item_wait_factor never stack.
+	"""
+	wait_factor = get_punctuation_wait_factor()
+	if wait_factor <= 0:
+		yield from speechSequence
+		return
+
+	chars = get_punctuation_pause_chars()
+	if not chars:
+		yield from speechSequence
+		return
+
+	pause_cmd = BreakCommand(wait_factor)
+	regex = _get_punctuation_regex(chars)
+
+	def is_non_blank_text(command: SpeechCmd) -> bool:
+		return isinstance(command, str) and bool(command.strip())
+
+	def emit(item: SpeechCmd, text_follows: bool) -> Iterator[SpeechCmd]:
+		if not isinstance(item, str):
+			yield item
+			return
+		parts = list(_split_punctuation_segments(item, regex))
+		for index, (kind, value) in enumerate(parts):
+			if kind == "text":
+				yield value
+				continue
+			yield value
+			if any(
+				pkind == "text" and pvalue.strip()
+				for pkind, pvalue in parts[index + 1:]
+			):
+				yield pause_cmd
+		# The item ends with a punctuation mark (its last significant
+		# character is a configured one); pause before the next text item.
+		stripped = item.rstrip()
+		if stripped and stripped[-1] in chars and text_follows:
+			yield pause_cmd
+
+	it = iter(speechSequence)
+	try:
+		previous = next(it)
+	except StopIteration:
+		return
+
+	for current in it:
+		yield from emit(previous, is_non_blank_text(current))
+		previous = current
+
+	yield from emit(previous, False)
+
+
+# @with_order_log("remove_silence")
+@with_speech_sequence_log("remove_silence")
+def remove_silence(
+		speechSequence: Iterable[SpeechCmd],
+) -> Iterator[SpeechCmd]:
+	"""
+	When the punctuation wait factor is 0, drop every BreakCommand from the
+	sequence so the voice is never silent between sentences - not even for a
+	fraction of a second.
+
+	* The pause is removed no matter which filter produced it (item wait,
+	  number wait, chinese space) or whether the caller inserted it, because
+	  this filter runs last in the pipeline.
+	* The configured punctuation-pause characters are stripped from the text
+	  as well, because the TTS engine itself pauses at marks such as "." or
+	  "؟" in the string it receives. Without stripping them the engine would
+	  still be silent even though no BreakCommand is left.
+	* A mark directly followed by a digit is preserved ("3.5", "12,500").
+	* When the factor is greater than 0 the sequence passes through
+	  unchanged, so the pauses requested by the other settings are preserved.
+	"""
+	if get_punctuation_wait_factor() > 0:
+		yield from speechSequence
+		return
+
+	chars = get_punctuation_pause_chars()
+	regex = _get_punctuation_removal_regex(chars) if chars else None
+
+	for command in speechSequence:
+		if isinstance(command, BreakCommand):
+			continue
+		if isinstance(command, str) and regex is not None:
+			command = regex.sub("", command)
+			if command:
+				yield command
+			continue
+		yield command
+
+
 def deduplicate_language_command(speechSequence):
 	"""
 	Stream *speech_sequence* and emit only the language-change commands
@@ -570,7 +747,9 @@ def inject_langchange_reorder(
 def order_move_to_start_register():
 	# stack: first in last out
 	filter_speechSequence.moveToEnd(speech_viewer, False)
+	filter_speechSequence.moveToEnd(remove_silence, False)
 	filter_speechSequence.moveToEnd(number_wait_factor, False)
+	filter_speechSequence.moveToEnd(inject_punctuation_pause, False)
 	filter_speechSequence.moveToEnd(item_wait_factor, False)
 	filter_speechSequence.moveToEnd(inject_chinese_space_pause, False)
 	filter_speechSequence.moveToEnd(inject_number_mode, False)
@@ -587,7 +766,9 @@ def order_move_to_end_register():
 	filter_speechSequence.moveToEnd(inject_number_mode, True)
 	filter_speechSequence.moveToEnd(inject_chinese_space_pause, True)
 	filter_speechSequence.moveToEnd(item_wait_factor, True)
+	filter_speechSequence.moveToEnd(inject_punctuation_pause, True)
 	filter_speechSequence.moveToEnd(number_wait_factor, True)
+	filter_speechSequence.moveToEnd(remove_silence, True)
 	filter_speechSequence.moveToEnd(speech_viewer, True)
 
 
@@ -600,6 +781,7 @@ def static_register():
 	filter_speechSequence.register(inject_number_language)
 	filter_speechSequence.register(inject_number_mode)
 	filter_speechSequence.register(number_wait_factor)
+	filter_speechSequence.register(remove_silence)
 	filter_speechSequence.register(speech_viewer)
 
 
@@ -608,6 +790,7 @@ def dynamic_register():
 
 	filter_speechSequence.register(ignore_comma_between_number)
 	filter_speechSequence.register(item_wait_factor)
+	filter_speechSequence.register(inject_punctuation_pause)
 
 
 def unregister():
@@ -619,6 +802,8 @@ def unregister():
 	filter_speechSequence.unregister(inject_number_mode)
 	filter_speechSequence.unregister(inject_number_language)
 	filter_speechSequence.unregister(item_wait_factor)
+	filter_speechSequence.unregister(inject_punctuation_pause)
 	filter_speechSequence.unregister(number_wait_factor)
+	filter_speechSequence.unregister(remove_silence)
 	filter_speechSequence.unregister(speech_viewer)
 	speech_dictionary.uninstall()

--- a/addon/synthDrivers/WorldVoice/pipeline/__init__.py
+++ b/addon/synthDrivers/WorldVoice/pipeline/__init__.py
@@ -27,6 +27,17 @@ _CH_SPACE_RE = re.compile(r"(?<=[\u4e00-\u9fa5])\s+(?=[\u4e00-\u9fa5])")
 
 _SENTENCE_END_RE = re.compile(r"^[.:;,?!](?:\s|$)")
 
+
+class PairBreakCommand(BreakCommand):
+	"""
+	BreakCommand inserted between digit pairs in pair number mode.
+
+	The subclass exists so that remove_silence (which strips every
+	BreakCommand when the punctuation wait factor is 0) can leave the
+	user-requested pair pauses intact: pair pauses are controlled by the
+	independent pair wait factor, not by the punctuation wait factor.
+	"""
+
 def with_order_log(label: str):
 	""" The order numbers are reversed because of recursion: the order number assigned earlier execution is greater than that of a later execution."""
 	def decorator(func):
@@ -137,6 +148,11 @@ def get_punctuation_pause_chars():
 def get_punctuation_pause_enabled():
 	settings = get_effective_pipeline_settings()
 	return settings.punctuation_pause_enabled
+
+
+def get_pair_wait_factor():
+	settings = get_effective_pipeline_settings()
+	return settings.scaled_pair_wait()
 
 
 # @with_order_log("speech_view")
@@ -382,9 +398,29 @@ def inject_number_language(
 		return
 
 
-def _translate_number(raw: str, mode: str, table: dict[int, str]) -> Iterator[str]:
+def _translate_number(raw: str, mode: str, table: dict[int, str]) -> Iterator[SpeechCmd]:
 	if mode == "value":
 		yield raw
+		return
+
+	if mode == "pair":
+		# Decimal numbers are read as a single value; only pure digit runs
+		# are grouped into pairs read from the left.
+		if "." in raw:
+			yield raw
+			return
+		sign = ""
+		digits = raw
+		if digits and digits[0] in "+-":
+			sign = digits[0]
+			digits = digits[1:]
+		pairs = [digits[i:i + 2] for i in range(0, len(digits), 2)]
+		pause = get_pair_wait_factor()
+		separator: SpeechCmd = PairBreakCommand(pause) if pause > 0 else " "
+		for index, pair in enumerate(pairs):
+			if index > 0:
+				yield separator
+			yield (sign + pair) if index == 0 else pair
 		return
 
 	previous_was_digit = False
@@ -645,7 +681,7 @@ def remove_silence(
 	regex = _get_punctuation_removal_regex(chars) if chars else None
 
 	for command in speechSequence:
-		if isinstance(command, BreakCommand):
+		if isinstance(command, BreakCommand) and not isinstance(command, PairBreakCommand):
 			continue
 		if isinstance(command, str) and regex is not None:
 			command = regex.sub("", command)

--- a/addon/synthDrivers/WorldVoice/pipeline/__init__.py
+++ b/addon/synthDrivers/WorldVoice/pipeline/__init__.py
@@ -134,6 +134,11 @@ def get_punctuation_pause_chars():
 	return settings.punctuation_pause_characters.strip()
 
 
+def get_punctuation_pause_enabled():
+	settings = get_effective_pipeline_settings()
+	return settings.punctuation_pause_enabled
+
+
 # @with_order_log("speech_view")
 @with_speech_sequence_log("speech_viewer")
 def speech_viewer(speechSequence):
@@ -553,6 +558,10 @@ def inject_punctuation_pause(
 	* An existing BreakCommand between two text items suppresses this pause,
 	  so the punctuation pause and item_wait_factor never stack.
 	"""
+	if not get_punctuation_pause_enabled():
+		yield from speechSequence
+		return
+
 	wait_factor = get_punctuation_wait_factor()
 	if wait_factor <= 0:
 		yield from speechSequence
@@ -624,6 +633,10 @@ def remove_silence(
 	* When the factor is greater than 0 the sequence passes through
 	  unchanged, so the pauses requested by the other settings are preserved.
 	"""
+	if not get_punctuation_pause_enabled():
+		yield from speechSequence
+		return
+
 	if get_punctuation_wait_factor() > 0:
 		yield from speechSequence
 		return

--- a/addon/synthDrivers/WorldVoice/pipeline/settings.py
+++ b/addon/synthDrivers/WorldVoice/pipeline/settings.py
@@ -14,6 +14,8 @@ DEFAULT_PIPELINE_SETTINGS = {
 	"item_wait_factor": 10,
 	"sayall_wait_factor": 10,
 	"chinesespace_wait_factor": 10,
+	"punctuation_wait_factor": 0,
+	"punctuation_pause_characters": "،؛,.;:!؟?…",
 }
 
 PIPELINE_CONFIG_KEYS = (
@@ -25,7 +27,20 @@ PIPELINE_CONFIG_KEYS = (
 	"item_wait_factor",
 	"sayall_wait_factor",
 	"chinesespace_wait_factor",
+	"punctuation_wait_factor",
+	"punctuation_pause_characters",
 )
+
+# Maximum pause (in milliseconds) injected after a punctuation mark.
+# The pause is intentionally capped so the voice never falls fully silent
+# at punctuation, no matter how high the configured factor is.
+MAX_PUNCTUATION_WAIT_MS = 500
+
+# Milliseconds of pause per unit of punctuation_wait_factor (0..100),
+# so the full slider range maps to 0..500ms on its own, independent of the
+# global wait factor. This keeps the punctuation pause audible even when the
+# global wait factor is 0.
+PUNCTUATION_WAIT_UNIT_MS = 5
 
 _last_scope_application: tuple[str, str] | None = None
 
@@ -40,6 +55,8 @@ class PipelineSettings:
 	item_wait_factor: int
 	sayall_wait_factor: int
 	chinesespace_wait_factor: int
+	punctuation_wait_factor: int
+	punctuation_pause_characters: str
 
 	@property
 	def global_factor_units(self) -> int:
@@ -56,6 +73,12 @@ class PipelineSettings:
 
 	def scaled_chinesespace_wait(self) -> int:
 		return self.global_factor_units * self.chinesespace_wait_factor
+
+	def scaled_punctuation_wait(self) -> int:
+		return min(
+			self.punctuation_wait_factor * PUNCTUATION_WAIT_UNIT_MS,
+			MAX_PUNCTUATION_WAIT_MS,
+		)
 
 
 def _pipeline_section(conf: Any) -> Any:
@@ -74,6 +97,9 @@ def _get_value(section: Any, key: str) -> Any:
 
 def load_pipeline_settings(conf: Any = config.conf) -> PipelineSettings:
 	pipeline = _pipeline_section(conf)
+	punctuation_pause_characters = str(
+		_get_value(pipeline, "punctuation_pause_characters")
+	).strip()
 	return PipelineSettings(
 		scope=str(_get_value(pipeline, "scope")),
 		ignore_comma_between_number=bool(_get_value(pipeline, "ignore_comma_between_number")),
@@ -83,6 +109,8 @@ def load_pipeline_settings(conf: Any = config.conf) -> PipelineSettings:
 		item_wait_factor=int(_get_value(pipeline, "item_wait_factor")),
 		sayall_wait_factor=int(_get_value(pipeline, "sayall_wait_factor")),
 		chinesespace_wait_factor=int(_get_value(pipeline, "chinesespace_wait_factor")),
+		punctuation_wait_factor=int(_get_value(pipeline, "punctuation_wait_factor")),
+		punctuation_pause_characters=punctuation_pause_characters,
 	)
 
 
@@ -115,6 +143,7 @@ def get_effective_pipeline_settings(synth: Any | None = None, conf: Any = config
 			settings.item_wait_factor = 0
 			settings.sayall_wait_factor = 0
 			settings.chinesespace_wait_factor = 0
+			settings.punctuation_wait_factor = 0
 			return settings
 		settings.ignore_comma_between_number = bool(
 			settings.global_factor_units * settings.ignore_comma_between_number
@@ -145,6 +174,15 @@ def get_effective_pipeline_settings(synth: Any | None = None, conf: Any = config
 				settings.chinesespace_wait_factor,
 			)
 		),
+		punctuation_wait_factor=int(
+			_runtime_value(
+				synth,
+				"punctuationwaitfactor",
+				"_punctuationwaitfactor",
+				settings.punctuation_wait_factor,
+			)
+		),
+		punctuation_pause_characters=str(settings.punctuation_pause_characters),
 	)
 
 
@@ -156,6 +194,7 @@ def apply_pipeline_settings_to_synth(synth: Any, settings: PipelineSettings) -> 
 	synth.itemwaitfactor = settings.item_wait_factor
 	synth.sayallwaitfactor = settings.sayall_wait_factor
 	synth.chinesespacewaitfactor = settings.chinesespace_wait_factor
+	synth.punctuationwaitfactor = settings.punctuation_wait_factor
 
 
 def apply_pipeline_settings_to_speech_config(settings: PipelineSettings, conf: Any = config.conf) -> None:
@@ -167,6 +206,7 @@ def apply_pipeline_settings_to_speech_config(settings: PipelineSettings, conf: A
 	speech_settings["itemwaitfactor"] = settings.item_wait_factor
 	speech_settings["sayallwaitfactor"] = settings.sayall_wait_factor
 	speech_settings["chinesespacewaitfactor"] = settings.chinesespace_wait_factor
+	speech_settings["punctuationwaitfactor"] = settings.punctuation_wait_factor
 
 
 def _load_scope_functions():

--- a/addon/synthDrivers/WorldVoice/pipeline/settings.py
+++ b/addon/synthDrivers/WorldVoice/pipeline/settings.py
@@ -17,6 +17,7 @@ DEFAULT_PIPELINE_SETTINGS = {
 	"punctuation_wait_factor": 0,
 	"punctuation_pause_enabled": True,
 	"punctuation_pause_characters": "،؛,.;:!؟?…",
+	"pair_wait_factor": 0,
 }
 
 PIPELINE_CONFIG_KEYS = (
@@ -31,6 +32,7 @@ PIPELINE_CONFIG_KEYS = (
 	"punctuation_wait_factor",
 	"punctuation_pause_enabled",
 	"punctuation_pause_characters",
+	"pair_wait_factor",
 )
 
 # Maximum pause (in milliseconds) injected after a punctuation mark.
@@ -43,6 +45,11 @@ MAX_PUNCTUATION_WAIT_MS = 500
 # global wait factor. This keeps the punctuation pause audible even when the
 # global wait factor is 0.
 PUNCTUATION_WAIT_UNIT_MS = 5
+
+# Pair pauses use the same unit scaling as punctuation pauses so that both
+# pause families behave consistently and remain audible regardless of the
+# global wait factor.
+PAIR_WAIT_UNIT_MS = 5
 
 _last_scope_application: tuple[str, str] | None = None
 
@@ -60,6 +67,7 @@ class PipelineSettings:
 	punctuation_wait_factor: int
 	punctuation_pause_enabled: bool
 	punctuation_pause_characters: str
+	pair_wait_factor: int
 
 	@property
 	def global_factor_units(self) -> int:
@@ -80,6 +88,12 @@ class PipelineSettings:
 	def scaled_punctuation_wait(self) -> int:
 		return min(
 			self.punctuation_wait_factor * PUNCTUATION_WAIT_UNIT_MS,
+			MAX_PUNCTUATION_WAIT_MS,
+		)
+
+	def scaled_pair_wait(self) -> int:
+		return min(
+			self.pair_wait_factor * PAIR_WAIT_UNIT_MS,
 			MAX_PUNCTUATION_WAIT_MS,
 		)
 
@@ -115,6 +129,7 @@ def load_pipeline_settings(conf: Any = config.conf) -> PipelineSettings:
 		punctuation_wait_factor=int(_get_value(pipeline, "punctuation_wait_factor")),
 		punctuation_pause_enabled=bool(_get_value(pipeline, "punctuation_pause_enabled")),
 		punctuation_pause_characters=punctuation_pause_characters,
+		pair_wait_factor=int(_get_value(pipeline, "pair_wait_factor")),
 	)
 
 
@@ -149,6 +164,7 @@ def get_effective_pipeline_settings(synth: Any | None = None, conf: Any = config
 			settings.chinesespace_wait_factor = 0
 			settings.punctuation_wait_factor = 0
 			settings.punctuation_pause_enabled = False
+			settings.pair_wait_factor = 0
 			return settings
 		settings.ignore_comma_between_number = bool(
 			settings.global_factor_units * settings.ignore_comma_between_number
@@ -196,6 +212,14 @@ def get_effective_pipeline_settings(synth: Any | None = None, conf: Any = config
 			)
 		),
 		punctuation_pause_characters=str(settings.punctuation_pause_characters),
+		pair_wait_factor=int(
+			_runtime_value(
+				synth,
+				"pairwaitfactor",
+				"_pairwaitfactor",
+				settings.pair_wait_factor,
+			)
+		),
 	)
 
 
@@ -209,6 +233,7 @@ def apply_pipeline_settings_to_synth(synth: Any, settings: PipelineSettings) -> 
 	synth.chinesespacewaitfactor = settings.chinesespace_wait_factor
 	synth.punctuationwaitfactor = settings.punctuation_wait_factor
 	synth.punctuationpauseenabled = settings.punctuation_pause_enabled
+	synth.pairwaitfactor = settings.pair_wait_factor
 
 
 def apply_pipeline_settings_to_speech_config(settings: PipelineSettings, conf: Any = config.conf) -> None:
@@ -222,6 +247,7 @@ def apply_pipeline_settings_to_speech_config(settings: PipelineSettings, conf: A
 	speech_settings["chinesespacewaitfactor"] = settings.chinesespace_wait_factor
 	speech_settings["punctuationwaitfactor"] = settings.punctuation_wait_factor
 	speech_settings["punctuationpauseenabled"] = settings.punctuation_pause_enabled
+	speech_settings["pairwaitfactor"] = settings.pair_wait_factor
 
 
 def _load_scope_functions():

--- a/addon/synthDrivers/WorldVoice/pipeline/settings.py
+++ b/addon/synthDrivers/WorldVoice/pipeline/settings.py
@@ -15,6 +15,7 @@ DEFAULT_PIPELINE_SETTINGS = {
 	"sayall_wait_factor": 10,
 	"chinesespace_wait_factor": 10,
 	"punctuation_wait_factor": 0,
+	"punctuation_pause_enabled": True,
 	"punctuation_pause_characters": "،؛,.;:!؟?…",
 }
 
@@ -28,6 +29,7 @@ PIPELINE_CONFIG_KEYS = (
 	"sayall_wait_factor",
 	"chinesespace_wait_factor",
 	"punctuation_wait_factor",
+	"punctuation_pause_enabled",
 	"punctuation_pause_characters",
 )
 
@@ -56,6 +58,7 @@ class PipelineSettings:
 	sayall_wait_factor: int
 	chinesespace_wait_factor: int
 	punctuation_wait_factor: int
+	punctuation_pause_enabled: bool
 	punctuation_pause_characters: str
 
 	@property
@@ -110,6 +113,7 @@ def load_pipeline_settings(conf: Any = config.conf) -> PipelineSettings:
 		sayall_wait_factor=int(_get_value(pipeline, "sayall_wait_factor")),
 		chinesespace_wait_factor=int(_get_value(pipeline, "chinesespace_wait_factor")),
 		punctuation_wait_factor=int(_get_value(pipeline, "punctuation_wait_factor")),
+		punctuation_pause_enabled=bool(_get_value(pipeline, "punctuation_pause_enabled")),
 		punctuation_pause_characters=punctuation_pause_characters,
 	)
 
@@ -144,6 +148,7 @@ def get_effective_pipeline_settings(synth: Any | None = None, conf: Any = config
 			settings.sayall_wait_factor = 0
 			settings.chinesespace_wait_factor = 0
 			settings.punctuation_wait_factor = 0
+			settings.punctuation_pause_enabled = False
 			return settings
 		settings.ignore_comma_between_number = bool(
 			settings.global_factor_units * settings.ignore_comma_between_number
@@ -182,6 +187,14 @@ def get_effective_pipeline_settings(synth: Any | None = None, conf: Any = config
 				settings.punctuation_wait_factor,
 			)
 		),
+		punctuation_pause_enabled=bool(
+			_runtime_value(
+				synth,
+				"punctuationpauseenabled",
+				"_punctuationpauseenabled",
+				settings.punctuation_pause_enabled,
+			)
+		),
 		punctuation_pause_characters=str(settings.punctuation_pause_characters),
 	)
 
@@ -195,6 +208,7 @@ def apply_pipeline_settings_to_synth(synth: Any, settings: PipelineSettings) -> 
 	synth.sayallwaitfactor = settings.sayall_wait_factor
 	synth.chinesespacewaitfactor = settings.chinesespace_wait_factor
 	synth.punctuationwaitfactor = settings.punctuation_wait_factor
+	synth.punctuationpauseenabled = settings.punctuation_pause_enabled
 
 
 def apply_pipeline_settings_to_speech_config(settings: PipelineSettings, conf: Any = config.conf) -> None:
@@ -207,6 +221,7 @@ def apply_pipeline_settings_to_speech_config(settings: PipelineSettings, conf: A
 	speech_settings["sayallwaitfactor"] = settings.sayall_wait_factor
 	speech_settings["chinesespacewaitfactor"] = settings.chinesespace_wait_factor
 	speech_settings["punctuationwaitfactor"] = settings.punctuation_wait_factor
+	speech_settings["punctuationpauseenabled"] = settings.punctuation_pause_enabled
 
 
 def _load_scope_functions():

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ The main speech role is configured through the NVDA voice settings panel, while 
 
 Speech pipeline settings control reading behavior related to numbers, pauses, and language processing. You can choose whether these settings apply to all supported synthesizers or only within WorldVoice.
 
-* Globally supported speech pipeline settings: ignore commas between numbers, number mode, item pause, number pause, Chinese pause, say-all pause
+* Globally supported speech pipeline settings: ignore commas between numbers, number mode, item pause, number pause, pair pause, Chinese pause, say-all pause
 * WorldVoice-only speech pipeline settings: detect language based on Unicode characters, number language
 
 * Detect language based on Unicode characters: When enabled, WorldVoice automatically determines the language or region from the text's Unicode characters and switches speech roles accordingly. Note: This feature may conflict with NVDA's automatic language switching, so it is recommended not to enable both at the same time.
@@ -44,7 +44,8 @@ Speech pipeline settings control reading behavior related to numbers, pauses, an
 * Number mode:
   * Numeric mode: Reads numbers as values. For example, "12345" is read as "twelve thousand three hundred forty-five."
   * Digit mode: Reads numbers digit by digit. For example, "12345" is read as "one two three four five."
-* Speech pause adjustment: Sets the pause length between numbers, items, Chinese text, and say-all reading. Smaller values mean shorter pauses, and 0 means no pause.
+  * Pair mode: Reads long connected digit strings in pairs from the left. For example, "12345678" is read as "twelve thirty-four fifty-six seventy-eight."
+* Speech pause adjustment: Sets the pause length between numbers, pairs, items, Chinese text, and say-all reading. Smaller values mean shorter pauses, and 0 means no pause.
 * Ignore commas between numbers: Ignores commas between digits when reading numbers to improve number-reading accuracy for specific speech roles.
 
 Globally supported speech pipeline settings can be adjusted through the NVDA speech settings panel or the WorldVoice speech pipeline panel. Speech pipeline settings that are not globally supported can only be adjusted through the NVDA speech settings panel.


### PR DESCRIPTION
## Summary

Adds a configurable pause after punctuation marks, with an editable list of punctuation-pause characters.

## What the feature does

A new "punctuation wait factor" setting (0..100) controls a short pause after punctuation:

- **factor > 0**: a pause is inserted after each configured mark. It works both between separate speech commands and *inside* a single sentence (screen readers usually send a whole sentence as one command). Consecutive marks count as one pause point, numeric separators such as `12,500` and `3.5` are skipped, an existing break suppresses stacking, and the pause is never the last command of a sequence (the voice cannot fall silent at the end).
- **factor 0**: no silence at all. `remove_silence` runs last in the pipeline, drops every `BreakCommand`, and strips the configured marks from the text itself so the TTS engine cannot insert its own natural pause at punctuation. A mark directly followed by a digit is preserved (`3.5`, `12,500`).

The pause length maps the factor to 0..500 ms on its own, independent of the global wait factor, so the punctuation pause stays audible even when the global wait factor is 0.

## Changes

- `pipeline/settings.py`: new `punctuation_wait_factor` and `punctuation_pause_characters` settings; `scaled_punctuation_wait()`.
- `pipeline/__init__.py`: `inject_punctuation_pause` and `remove_silence` filters with regex helpers; both filters are wired into `static_register` / `dynamic_register` / `unregister` and ordered last (before `speech_viewer`).
- `synthDrivers/WorldVoice/__init__.py`: config.spec entries (including `remove_silence` log key used by the decorator), the `punctuationwaitfactor` driver setting, and dynamic filter registration.
- `VoiceSettingsDialogs.py`: editable "Punctuation pause characters" field saved to config.

## Bundled micro-optimizations (no behavior change)

- `with_speech_sequence_log`: `uuid.uuid4()` is now generated only when logging is actually enabled.
- `inject_number_language`: when `numlan` is `"default"` the number-language wrapper commands are always dropped downstream, so the pass-through avoids scanning every string for numbers.

## Testing

- Unit-tested with a mocked NVDA environment: 43 tests covering punctuation splitting, numeric guards, existing-break suppression, trailing-pause avoidance, remove_silence at factor 0 (including punctuation stripping and digit-protection) and passthrough at factor > 0; all pass.
- `py_compile` clean on all changed files.
- Runs on NVDA 2026.2beta10; verified in reading, say-all and the voice settings dialog.
